### PR TITLE
feat: add multipart S3 upload/download with dynamic chunking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sbioapputils"
-version = "1.0.38"
+version = "1.0.39"
 authors = [
   { name="Superbio AI", email="smorgan@superbio.ai" },
 ]

--- a/sbioapputils/app_runner/app_runner_utils.py
+++ b/sbioapputils/app_runner/app_runner_utils.py
@@ -4,6 +4,8 @@ import os
 import requests
 from logging.handlers import WatchedFileHandler
 
+from sbioapputils.app_runner.s3_transfer import multipart_download, multipart_upload
+
 
 class AppRunnerUtils:
 
@@ -27,6 +29,37 @@ class AppRunnerUtils:
                                             region_name=region)
             s3 = session.resource('s3')
             return s3.Bucket(bucket)
+
+    @classmethod
+    def get_s3_client(cls, external_bucket=None):
+        """Return a boto3 S3 **client** and the resolved bucket name.
+
+        Unlike ``get_s3_bucket`` (which returns a *resource* Bucket object),
+        this method returns a low-level client suitable for
+        ``download_file`` / ``upload_file`` with ``TransferConfig``.
+
+        Returns:
+            tuple: (s3_client, bucket_name)
+        """
+        if external_bucket:
+            role_arn = os.environ.get("ROLE_ARN")
+            credentials = cls.assume_role(role_arn)
+            s3_client = boto3.client(
+                's3',
+                aws_access_key_id=credentials['AccessKeyId'],
+                aws_secret_access_key=credentials['SecretAccessKey'],
+                aws_session_token=credentials['SessionToken'],
+                region_name=os.environ.get("AWS_REGION"),
+            )
+            return s3_client, external_bucket
+        else:
+            s3_client = boto3.client(
+                's3',
+                aws_access_key_id=os.environ.get("AWS_ACCESS_KEY_ID"),
+                aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
+                region_name=os.environ.get("AWS_REGION"),
+            )
+            return s3_client, os.environ.get("AWS_DATASET_BUCKET")
 
     @classmethod
     def assume_role(cls, role_arn):
@@ -74,9 +107,9 @@ class AppRunnerUtils:
         if "EXTERNAL_BUCKET" in os.environ and "SAVE_RESULTS_TO_USER_DATA" in os.environ and eval(
                 os.environ.get("SAVE_RESULTS_TO_USER_DATA")):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
-        bucket = cls.get_s3_bucket(external_bucket)
+        s3_client, bucket_name = cls.get_s3_client(external_bucket)
         for src_file in src_files:
-            cls._upload(bucket, src_file, dest)
+            cls._upload(s3_client, bucket_name, src_file, dest)
 
     @classmethod
     def upload_file(cls, job_id: str, src_file: str):
@@ -85,15 +118,13 @@ class AppRunnerUtils:
         if "EXTERNAL_BUCKET" in os.environ and "SAVE_RESULTS_TO_USER_DATA" in os.environ and eval(
                 os.environ.get("SAVE_RESULTS_TO_USER_DATA")):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
-        bucket = cls.get_s3_bucket(external_bucket)
-        cls._upload(bucket, src_file, dest)
+        s3_client, bucket_name = cls.get_s3_client(external_bucket)
+        cls._upload(s3_client, bucket_name, src_file, dest)
 
     @classmethod
-    def _upload(cls, bucket, src: str, dest_folder: str):
-        f = open(src, "rb")
+    def _upload(cls, s3_client, bucket_name: str, src: str, dest_folder: str):
         dest_file = f'{dest_folder}{src}'
-        bucket.put_object(Key=dest_file, Body=f.read())
-        f.close()
+        multipart_upload(s3_client, bucket_name, src, dest_file)
         logging.info(f'Uploaded a file {dest_file}')
 
     @classmethod
@@ -103,11 +134,8 @@ class AppRunnerUtils:
         if "EXTERNAL_BUCKET" in os.environ and cls.get_file_is_remote(source_file_path, config_v2):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
 
-        bucket = cls.get_s3_bucket(external_bucket)
-        obj = bucket.Object(source_file_path)
-        f = open(dest_file_path, "wb")
-        f.write(obj.get()['Body'].read())
-        f.close()
+        s3_client, bucket_name = cls.get_s3_client(external_bucket)
+        multipart_download(s3_client, bucket_name, source_file_path, dest_file_path)
 
     @classmethod
     def load_file(cls, source_file_path: str):

--- a/sbioapputils/app_runner/s3_transfer.py
+++ b/sbioapputils/app_runner/s3_transfer.py
@@ -1,0 +1,140 @@
+import logging
+import os
+import time
+
+from boto3.s3.transfer import TransferConfig
+
+logger = logging.getLogger(__name__)
+
+MB = 1024 * 1024
+GB = 1024 * MB
+
+
+def get_transfer_config(file_size):
+    """Return a dynamic TransferConfig based on file size.
+
+    Small files  (< 1 GB):  16 MB chunks, 10 threads
+    Medium files (< 10 GB): 64 MB chunks, 15 threads
+    Large files  (>= 10 GB): 256 MB chunks, 20 threads
+    """
+    if file_size < 1 * GB:
+        chunk, concurrency = 16 * MB, 10
+    elif file_size < 10 * GB:
+        chunk, concurrency = 64 * MB, 15
+    else:
+        chunk, concurrency = 256 * MB, 20
+
+    config = TransferConfig(
+        multipart_threshold=16 * MB,
+        multipart_chunksize=chunk,
+        max_concurrency=concurrency,
+        use_threads=True,
+    )
+    return config, chunk, concurrency
+
+
+def multipart_download(s3_client, bucket, s3_key, local_path, progress=True):
+    """Download a file from S3 using multipart transfer with progress logging.
+
+    Args:
+        s3_client: A boto3 S3 client instance.
+        bucket: The S3 bucket name.
+        s3_key: The S3 object key to download.
+        local_path: The local file path to save the downloaded file.
+        progress: Whether to log download progress (default True).
+    """
+    os.makedirs(os.path.dirname(local_path) or ".", exist_ok=True)
+
+    head = s3_client.head_object(Bucket=bucket, Key=s3_key)
+    file_size = head["ContentLength"]
+    file_size_gb = file_size / GB
+    filename = os.path.basename(s3_key)
+
+    config, chunk, concurrency = get_transfer_config(file_size)
+    logger.info(
+        "Downloading %s (%.2f GB) [%d MB x %d threads]",
+        filename, file_size_gb, chunk // MB, concurrency,
+    )
+
+    state = {"bytes": 0, "last_pct": 0}
+    start = time.time()
+
+    def _callback(n):
+        state["bytes"] += n
+        pct = int(state["bytes"] / file_size * 100) if file_size > 0 else 100
+        if pct >= state["last_pct"] + 5:
+            state["last_pct"] = pct
+            elapsed = time.time() - start
+            speed = (state["bytes"] / MB) / elapsed if elapsed > 0 else 0
+            gb_done = state["bytes"] / GB
+            logger.info(
+                "  %s: %.2f/%.2f GB (%d%%) - %.0f MB/s",
+                filename, gb_done, file_size_gb, pct, speed,
+            )
+
+    callback = _callback if progress else None
+
+    s3_client.download_file(
+        Bucket=bucket, Key=s3_key, Filename=local_path,
+        Config=config, Callback=callback,
+    )
+
+    elapsed = time.time() - start
+    mins, secs = int(elapsed // 60), int(elapsed % 60)
+    avg = file_size_gb / (elapsed / 60) if elapsed > 0 else 0
+    logger.info(
+        "  %s downloaded in %dm %ds (%.2f GB/min)",
+        filename, mins, secs, avg,
+    )
+
+
+def multipart_upload(s3_client, bucket, local_path, s3_key, progress=True):
+    """Upload a file to S3 using multipart transfer with progress logging.
+
+    Args:
+        s3_client: A boto3 S3 client instance.
+        bucket: The S3 bucket name.
+        local_path: The local file path to upload.
+        s3_key: The S3 object key for the destination.
+        progress: Whether to log upload progress (default True).
+    """
+    file_size = os.path.getsize(local_path)
+    file_size_gb = file_size / GB
+    filename = os.path.basename(local_path)
+
+    config, chunk, concurrency = get_transfer_config(file_size)
+    logger.info(
+        "Uploading %s (%.2f GB) -> %s [%d MB x %d threads]",
+        filename, file_size_gb, s3_key, chunk // MB, concurrency,
+    )
+
+    state = {"bytes": 0, "last_pct": 0}
+    start = time.time()
+
+    def _callback(n):
+        state["bytes"] += n
+        pct = int(state["bytes"] / file_size * 100) if file_size > 0 else 100
+        if pct >= state["last_pct"] + 5:
+            state["last_pct"] = pct
+            elapsed = time.time() - start
+            speed = (state["bytes"] / MB) / elapsed if elapsed > 0 else 0
+            gb_done = state["bytes"] / GB
+            logger.info(
+                "  %s: %.2f/%.2f GB (%d%%) - %.0f MB/s",
+                filename, gb_done, file_size_gb, pct, speed,
+            )
+
+    callback = _callback if progress else None
+
+    s3_client.upload_file(
+        Filename=local_path, Bucket=bucket, Key=s3_key,
+        Config=config, Callback=callback,
+    )
+
+    elapsed = time.time() - start
+    mins, secs = int(elapsed // 60), int(elapsed % 60)
+    avg = file_size_gb / (elapsed / 60) if elapsed > 0 else 0
+    logger.info(
+        "  %s uploaded in %dm %ds (%.2f GB/min)",
+        filename, mins, secs, avg,
+    )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
       name="sbioapputils",
-      version="1.0.38",
+      version="1.0.39",
       description="Superbio app runner utils",
       author="Superbio AI",
       author_email="smorgan@superbio.ai",


### PR DESCRIPTION
## Summary
Multipart S3 transfer support added to sbioapputils. Previously all uploads/downloads loaded entire files into memory — this caused issues with large files.

## Changes

### New: `sbioapputils/app_runner/s3_transfer.py`
- `get_transfer_config(file_size)` — dynamic chunk size & concurrency based on file size:
  - < 1 GB: 16 MB chunks, 10 threads
  - < 10 GB: 64 MB chunks, 15 threads
  - >= 10 GB: 256 MB chunks, 20 threads
- `multipart_download()` — S3 download with TransferConfig + progress logging
- `multipart_upload()` — S3 upload with TransferConfig + progress logging

### Updated: `app_runner_utils.py`
- Added `get_s3_client()` — returns boto3 S3 **client** (not resource) + bucket name
- `_upload()` — replaced `put_object(Body=f.read())` with `multipart_upload`
- `download_file()` — replaced `obj.get()['Body'].read()` with `multipart_download`
- All existing method signatures preserved (backward compatible)

### Version bump
- `setup.py` and `pyproject.toml`: `1.0.38` → `1.0.39`

## Why
- `put_object(Body=f.read())` loads entire file into memory — fails on large files
- No multipart = no parallelism, slow transfers
- No progress visibility for long-running transfers