### PR TITLE
fix: add safe default values to eval() calls to prevent SyntaxError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sbioapputils"
-version = "1.0.39"
+version = "1.0.40"
 authors = [
   { name="Superbio AI", email="smorgan@superbio.ai" },
 ]

--- a/sbioapputils/app_runner/app_runner_utils.py
+++ b/sbioapputils/app_runner/app_runner_utils.py
@@ -105,7 +105,7 @@ class AppRunnerUtils:
         dest = cls.get_job_folder(job_id)
         external_bucket = None
         if "EXTERNAL_BUCKET" in os.environ and "SAVE_RESULTS_TO_USER_DATA" in os.environ and eval(
-                os.environ.get("SAVE_RESULTS_TO_USER_DATA")):
+                os.environ.get("SAVE_RESULTS_TO_USER_DATA", "False")):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
         s3_client, bucket_name = cls.get_s3_client(external_bucket)
         for src_file in src_files:
@@ -116,7 +116,7 @@ class AppRunnerUtils:
         dest = cls.get_job_folder(job_id)
         external_bucket = None
         if "EXTERNAL_BUCKET" in os.environ and "SAVE_RESULTS_TO_USER_DATA" in os.environ and eval(
-                os.environ.get("SAVE_RESULTS_TO_USER_DATA")):
+                os.environ.get("SAVE_RESULTS_TO_USER_DATA", "False")):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
         s3_client, bucket_name = cls.get_s3_client(external_bucket)
         cls._upload(s3_client, bucket_name, src_file, dest)
@@ -183,8 +183,7 @@ class AppRunnerUtils:
     @classmethod
     def get_job_config(cls, job_id: str):
         if "JOB_CONFIG" in os.environ:
-            response = eval(os.environ.get("JOB_CONFIG"))
-            return response
+            return eval(os.environ.get("JOB_CONFIG", "{}"))
         else:
             token = cls.get_api_token()
             api_url = os.environ.get("SBIO_API_URL")
@@ -205,16 +204,14 @@ class AppRunnerUtils:
     @classmethod
     def get_job_run_by_admin(cls):
         if "RUN_BY_ADMIN" in os.environ:
-            response = eval(os.environ.get("RUN_BY_ADMIN"))
-            return response
+            return eval(os.environ.get("RUN_BY_ADMIN", "False"))
         else:
             return False
 
     @classmethod
     def get_job_config_v2(cls, job_id: str):
         if "JOB_CONFIG" in os.environ:
-            response = eval(os.environ.get("JOB_CONFIG"))
-            return response
+            return eval(os.environ.get("JOB_CONFIG", "{}"))
         else:
             token = cls.get_api_token()
             api_url = os.environ.get("SBIO_API_URL")

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
       name="sbioapputils",
-      version="1.0.39",
+      version="1.0.40",
       description="Superbio app runner utils",
       author="Superbio AI",
       author_email="smorgan@superbio.ai",


### PR DESCRIPTION
## Problem
`eval(os.environ.get("SAVE_RESULTS_TO_USER_DATA"))` throws `SyntaxError: File "<string>", line 0` when the environment variable is empty or not set properly.

## Root Cause
`os.environ.get()` returns `None` or empty string when the env var is missing/empty, causing `eval(None)` or `eval("")` to crash.

## Fix
Added safe default values to all `eval(os.environ.get(...))` calls:

| Env Var | Default | Reason |
|---|---|---|
| `SAVE_RESULTS_TO_USER_DATA` | `"False"` | Boolean - eval("False") returns False |
| `RUN_BY_ADMIN` | `"False"` | Boolean - eval("False") returns False |
| `JOB_CONFIG` | `"{}"` | Dict - eval("{}") returns empty dict |

## Version
Bumped from `1.0.39` → `1.0.40`