### PR TITLE
fix: replace eval() with safe string comparison for SAVE_RESULTS_TO_USER_DATA env var

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sbioapputils"
-version = "1.0.40"
+version = "1.0.41"
 authors = [
   { name="Superbio AI", email="smorgan@superbio.ai" },
 ]

--- a/sbioapputils/app_runner/app_runner_utils.py
+++ b/sbioapputils/app_runner/app_runner_utils.py
@@ -104,8 +104,7 @@ class AppRunnerUtils:
     def upload_result_files(cls, job_id: str, src_files: list):
         dest = cls.get_job_folder(job_id)
         external_bucket = None
-        if "EXTERNAL_BUCKET" in os.environ and "SAVE_RESULTS_TO_USER_DATA" in os.environ and eval(
-                os.environ.get("SAVE_RESULTS_TO_USER_DATA", "False")):
+        if "EXTERNAL_BUCKET" in os.environ and os.environ.get("SAVE_RESULTS_TO_USER_DATA", "").lower() in ("true", "1", "yes"):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
         s3_client, bucket_name = cls.get_s3_client(external_bucket)
         for src_file in src_files:
@@ -115,8 +114,7 @@ class AppRunnerUtils:
     def upload_file(cls, job_id: str, src_file: str):
         dest = cls.get_job_folder(job_id)
         external_bucket = None
-        if "EXTERNAL_BUCKET" in os.environ and "SAVE_RESULTS_TO_USER_DATA" in os.environ and eval(
-                os.environ.get("SAVE_RESULTS_TO_USER_DATA", "False")):
+        if "EXTERNAL_BUCKET" in os.environ and os.environ.get("SAVE_RESULTS_TO_USER_DATA", "").lower() in ("true", "1", "yes"):
             external_bucket = os.environ.get("EXTERNAL_BUCKET")
         s3_client, bucket_name = cls.get_s3_client(external_bucket)
         cls._upload(s3_client, bucket_name, src_file, dest)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
       name="sbioapputils",
-      version="1.0.40",
+      version="1.0.41",
       description="Superbio app runner utils",
       author="Superbio AI",
       author_email="smorgan@superbio.ai",


### PR DESCRIPTION
## Summary
- `eval()` on an empty `SAVE_RESULTS_TO_USER_DATA` environment variable causes `SyntaxError: invalid syntax` in `upload_file` and `upload_result_files`
- Replaced unsafe `eval()` calls with `.lower() in ("true", "1", "yes")` string comparison
- Handles empty strings, missing env vars, and removes `eval()` security risk

## Test plan
- [x] Verify `upload_file` works when `SAVE_RESULTS_TO_USER_DATA` is empty string
- [x] Verify `upload_file` works when `SAVE_RESULTS_TO_USER_DATA` is `"True"`
- [x] Verify `upload_result_files` works with same scenarios
